### PR TITLE
9.0.0 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.clj-kondo/.cache/
+.lsp/.cache/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/
 To use stardog-clj, follow these simple steps:
 
 1. Install Stardog. See [Getting Stardog](https://www.stardog.com/docs/#_getting_stardog) for details.
-2. In your application, add the stardog-clj dependency to your project.clj file, or equivalent build tool.  For example, `[stardog-clj "7.8.2"]`
+2. In your application, add the stardog-clj dependency to your project.clj file, or equivalent build tool.  For example, `[stardog-clj "9.0.0"]`
 3. In your application, create a database specification `(create-db-spec database "http://localhost:5820/" "admin" "admin" true)`
 4. You can use this specification to make a connection pool with `(make-datasource spec)`
 5. Use `(with-connection-pool [conn datasource])` to start using the connection pool

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The test suite does run with the assumption there is a Stardog database server r
 
 ## License
 
-Copyright 2014, 2015, 2016, 2017, 2018, 2019, 2020 Stardog Union
+Copyright 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Stardog Union
 
 Copyright 2014 Paula Gearon
 

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(defproject stardog-clj "9.0.0-SNAPSHOT"
+(defproject stardog-clj "9.0.0"
   :description "Stardog-clj: Clojure bindings for Stardog"
   :url "http://stardog.com"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
   :license {:name "Apache License"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.complexible.stardog/client-http "7.8.2" :extension "pom"]
+                 [com.complexible.stardog/client-http "9.0.0" :extension "pom"]
                  [org.clojure/tools.logging "1.1.0"]
                  [com.google.guava/guava "31.0.1-jre"]
                  [ch.qos.logback/logback-classic "1.2.6"]]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(defproject stardog-clj "7.8.2"
+(defproject stardog-clj "9.0.0-SNAPSHOT"
   :description "Stardog-clj: Clojure bindings for Stardog"
   :url "http://stardog.com"
   :license {:name "Apache License"

--- a/src/stardog/core.clj
+++ b/src/stardog/core.clj
@@ -74,7 +74,7 @@
         pool-config (-> (ConnectionPoolConfig/using con-config)
                         (.minPool min-pool)
                         (.maxIdle max-idle)
-                        (.minPool min-pool))
+                        (.maxPool max-pool))
         pool (.create pool-config)]
     {:ds pool}))
 

--- a/src/stardog/values.clj
+++ b/src/stardog/values.clj
@@ -15,7 +15,7 @@
 
 (ns stardog.values
   (:import [com.stardog.stark IRI Literal BNode Values Datatype]
-           [com.stardog.stark.impl IRIImpl TypedLiteral BooleanLiteral LanguageLiteral]
+           [com.stardog.stark.impl CalendarLiteral IRIImpl TypedLiteral BooleanLiteral LanguageLiteral]
            [java.util Date GregorianCalendar UUID Map]
            [javax.xml.datatype DatatypeConfigurationException DatatypeFactory XMLGregorianCalendar]))
 
@@ -142,6 +142,10 @@
   (standardize [v] (typed-value v))
   BNode
   (standardize [v] (keyword "_" (str "b" (.getID v)))))
+
+  CalendarLiteral
+  (standardize [v]
+    (.getTime (.toGregorianCalendar (.unwrap v)))))
 
 (defn as-uri
   "Create a URI from a String"

--- a/src/stardog/values.clj
+++ b/src/stardog/values.clj
@@ -141,7 +141,7 @@
   Literal
   (standardize [v] (typed-value v))
   BNode
-  (standardize [v] (keyword "_" (str "b" (.getID v)))))
+  (standardize [v] (keyword "_" (str "b" (.id v))))
 
   CalendarLiteral
   (standardize [v]

--- a/test/stardog/test/values.clj
+++ b/test/stardog/test/values.clj
@@ -42,7 +42,10 @@
              (standardize (convert d)) => d))
        (fact "UUID to UUID"
              (let [u (UUID/randomUUID)]
-             (standardize (convert u)) => u)))
+               (standardize (convert u)) => u))
+       (fact "Bnode to Keyword"
+             (let [b (com.stardog.stark.impl.BNodeImpl. "test")]
+               (standardize b) => :_/btest)))
 
 (facts "URI Creation"
        (fact "Creating a URI from a String"


### PR DESCRIPTION
Prepares this library for upcoming stardog 9.0.0 release.

Testing requires installing stardog 9.0.0 and installing the java API to your local maven repository (`./gradlew install` from stardog repo on release/9.0.0 branch).

Cannot release until stardog 9.0.0 is out. Once that is done the release process should increment the project.clj version to 9.0.0

Two bugs were fixed as well:
4cd9088a56d0ea4bebfb27151af8e9a554bcdb2e
245753104a473ad38c9f5e924e8da0b3e97a8753

Tests pass with java 11. Java 8 can no longer be supported because stardog 9.0.0 is compiled with java 11, which produces class files that java 8 will not be able to support.